### PR TITLE
windows: Don't try to install to c:\ProgramData if c:\Program Files fails

### DIFF
--- a/win/installer/common.nsh
+++ b/win/installer/common.nsh
@@ -5049,17 +5049,10 @@
 !endif
 
       ; If the user doesn't have write access to the installation directory set
-      ; the installation directory to a subdirectory of the All Users application
-      ; directory and if the user can't write to that location set the installation
-      ; directory to a subdirectory of the users local application directory
-      ; (e.g. non-roaming).
+      ; the installation directory to a subdirectory of the user's local
+      ; application directory (e.g. non-roaming).
       ${CanWriteToInstallDir} $R9
       StrCmp "$R9" "false" +1 finish_check_install_dir
-
-      SetShellVarContext all      ; Set SHCTX to All Users
-      StrCpy $INSTDIR "$APPDATA\${BrandFullName}\"
-      ${CanWriteToInstallDir} $R9
-      StrCmp "$R9" "false" +2 +1
       StrCpy $INSTDIR "$LOCALAPPDATA\${BrandFullName}\"
 
       finish_check_install_dir:


### PR DESCRIPTION
I ran into this issue while trying to improve the handling for per-user installations. Basically, the installer is deciding whether to use %LOCALAPPDATA% based on whether there is write access to c:\ProgramData.

In practice this is a minor issue. By default Windows will let any user write to that location. 
## Commit comment

Previously the Windows installer was intending to try each of the following folders in turn until one with write access was found
#### Windows XP
- c:\Program Files
- c:\Documents and Settings\All Users\Application Data
- c:\Documents and Settings<current user>\Application Data
#### Windows 7
- c:\Program Files or c:\Program Files (x86)
- c:\ProgramData
- c:\Users<current user>\AppData\roaming

What was actually happening was that if the second path was checked for and
was found to be writable by the current user, then the 3rd option would be
chosen. If the current user did not have write access to the second path,
however, then that path would be chosen.

A user running the installer with administrative access should be able to put
programs in the first path. Should this not be the case, it would be better to
abort the installation rather than look for an alternate place to install the
software system-wide.

With this patch the behavior is as follows. First the installer will check
whether it has write access to the system wide location ("c:\Program Files" or
"c:\Program Files (x86)"). If this fails it will fall pack on a per-user
installation.
