### PR TITLE
Remove SHCTX\Software\Zotero key from registry when uninstalling.

### DIFF
--- a/win/installer/common.nsh
+++ b/win/installer/common.nsh
@@ -2456,6 +2456,10 @@
 
       outerdecrement:
       IntOp $R6 $R6 - 1 ; decrement the outer loop's counter when the key is deleted successfully.
+      ; Attempt to delete Software/Zotero. There is nothing we can do if the
+      ; user lacks permissions to delete this key.
+      DeleteRegKey /ifempty SHCTX "$R9"
+      ClearErrors
       GoTo outerloop
 
       end:


### PR DESCRIPTION
The uninstaller walks through keys under SHCTX\Software\Zotero. It does this
in two nested loops. After deleting known child keys it deletes the parent
key provided that there are no children left.

Previously this final conditional deletion was only happening in the inner
loop. This left an empty Software\Zotero key when the uninstaller completed.
