### PR TITLE
windows installer: DeleteRelativeProfiles was leaving an item on the stack

### DIFF
--- a/win/installer/common.nsh
+++ b/win/installer/common.nsh
@@ -3291,7 +3291,7 @@
       Pop $R6
       Pop $R7
       Pop $R8
-      Exch $R9
+      Pop $R9
     FunctionEnd
 
     !verbose pop


### PR DESCRIPTION
This fixes a minor bug in DeleteRelativeProfiles. It was not cleaning up the stack on exit.
