### PR TITLE
Do not register Zotero as the Start Menu Internet Link.

### DIFF
--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -319,20 +319,6 @@ Section "-Application" APP_IDX
   ; Register zotero protocol handler
   ${SetHandlers}
 
-  ; The following keys should only be set if we can write to HKLM
-  ${If} $TmpVal == "HKLM"
-    ; If we are writing to HKLM and create either the desktop or start menu
-    ; shortcuts set IconsVisible to 1 otherwise to 0.
-    ${StrFilter} "${FileMainEXE}" "+" "" "" $R9
-    StrCpy $0 "Software\Clients\StartMenuInternet\$R9\InstallInfo"
-    ${If} $AddDesktopSC == ${DESKTOP_SHORTCUT_ENABLED}
-    ${OrIf} $AddStartMenuSC == ${START_MENU_SHORTCUT_ENABLED}
-      WriteRegDWORD HKLM "$0" "IconsVisible" 1
-    ${Else}
-      WriteRegDWORD HKLM "$0" "IconsVisible" 0
-    ${EndIf}
-  ${EndIf}
-
   ; These need special handling on uninstall since they may be overwritten by
   ; an install into a different location.
   StrCpy $0 "Software\Microsoft\Windows\CurrentVersion\App Paths\${FileMainEXE}"

--- a/win/installer/uninstaller.nsi
+++ b/win/installer/uninstaller.nsi
@@ -246,23 +246,6 @@ Section "Uninstall"
     ${un.GetSecondInstallPath} "Software\Zotero" $R9
   ${EndIf}
 
-  StrCpy $0 "Software\Clients\StartMenuInternet\${FileMainEXE}\shell\open\command"
-  ReadRegStr $R1 HKLM "$0" ""
-  ${un.RemoveQuotesFromPath} "$R1" $R1
-  ${un.GetParent} "$R1" $R1
-
-  ; Only remove the StartMenuInternet key if it refers to this install location.
-  ; The StartMenuInternet registry key is independent of the default browser
-  ; settings. The XPInstall base un-installer always removes this key if it is
-  ; uninstalling the default browser and it will always replace the keys when
-  ; installing even if there is another install of Firefox that is set as the
-  ; default browser. Now the key is always updated on install but it is only
-  ; removed if it refers to this install location.
-  ${If} "$INSTDIR" == "$R1"
-    DeleteRegKey HKLM "Software\Clients\StartMenuInternet\${FileMainEXE}"
-    DeleteRegValue HKLM "Software\RegisteredApplications" "${AppRegName}"
-  ${EndIf}
-
   StrCpy $0 "Software\Microsoft\Windows\CurrentVersion\App Paths\${FileMainEXE}"
   ${If} $R9 == "false"
     DeleteRegKey HKLM "$0"


### PR DESCRIPTION
Windows XP and Windows Vista have a special Start Menu Internet Link in the start menu. This menu item can be customized by registering an application in the registry under Software\Clients\StartMenuInternet. This registration is ignored in Windows 7 and Windows 8.

Zotero's installer was partially filling in this information, and the uninstaller was failing to remove it.

The uninstaller was also deleting a key under Software\RegisteredApplications. This key is used for the Windows "Default Programs" feature, which Zotero is not using. The installer was not writing values to this key.
