### PR TITLE
Uninstaller should not clean up VirtualStore folder for current user.

### DIFF
--- a/win/installer/shared.nsh
+++ b/win/installer/shared.nsh
@@ -40,10 +40,6 @@
   ${SetAppKeys}
   ${FixClassKeys}
   ${SetUninstallKeys}
-
-  ; Remove files that may be left behind by the application in the
-  ; VirtualStore directory.
-  ${CleanVirtualStore}
 !macroend
 !define PostUpdate "!insertmacro PostUpdate"
 

--- a/win/installer/uninstaller.nsi
+++ b/win/installer/uninstaller.nsi
@@ -56,7 +56,6 @@ VIAddVersionKey "FileDescription" "${BrandShortName} Helper"
 VIAddVersionKey "OriginalFilename" "helper.exe"
 
 !insertmacro AddHandlerValues
-!insertmacro CleanVirtualStore
 !insertmacro ElevateUAC
 !insertmacro GetLongPath
 !insertmacro GetPathFromString
@@ -76,7 +75,6 @@ VIAddVersionKey "OriginalFilename" "helper.exe"
 !insertmacro un.ChangeMUIHeaderImage
 !insertmacro un.CheckForFilesInUse
 !insertmacro un.CleanUpdatesDir
-!insertmacro un.CleanVirtualStore
 !insertmacro un.DeleteRelativeProfiles
 !insertmacro un.DeleteShortcuts
 !insertmacro un.GetLongPath
@@ -279,10 +277,6 @@ Section "Uninstall"
 
   ; Remove the updates directory for Vista and above
   ${un.CleanUpdatesDir} "Zotero\Standalone"
-
-  ; Remove files that may be left behind by the application in the
-  ; VirtualStore directory.
-  ${un.CleanVirtualStore}
 
   ; Parse the uninstall log to unregister dll's and remove all installed
   ; files / directories this install is responsible for.


### PR DESCRIPTION
The uninstaller was deleting any VirtualStore items that may have been created by Zotero. This is not necessary because Zotero's executable contains a manifest which prevents Windows from using file virtualization.
