### PR TITLE
Ignore build products and backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *~
+dist
+staging
+xulrunner


### PR DESCRIPTION
Add a `.gitignore` file so that we don't see builds or *~ backup files in `git status`.
