### PR TITLE
Update optimizejars.py : parentheses in "print"

### DIFF
--- a/scripts/optimizejars.py
+++ b/scripts/optimizejars.py
@@ -319,14 +319,14 @@ def optimizejar(jar, outjar, inlog = None):
         outfd.seek(out_offset)
         outfd.write(dirend_data)
 
-    print "Stripped %d bytes" % total_stripped
-    print "%s %d/%d in %s" % (("Ordered" if inlog is not None else "Deoptimized"),
+    print ("Stripped %d bytes") % total_stripped
+    print ("%s %d/%d in %s") % (("Ordered" if inlog is not None else "Deoptimized"),
                               reordered_count, len(central_directory), outjar)
     outfd.close()
     return outlog
         
 if len(sys.argv) != 5:
-    print "Usage: --optimize|--deoptimize %s JAR_LOG_DIR IN_JAR_DIR OUT_JAR_DIR" % sys.argv[0]
+    print ("Usage: --optimize|--deoptimize %s JAR_LOG_DIR IN_JAR_DIR OUT_JAR_DIR") % sys.argv[0]
     exit(1)
 
 jar_regex = re.compile("\\.jar?$")


### PR DESCRIPTION
I got some errors while trying to build Standalone on Win7 and these changes seem to solve them. But please check that's right (I'm actually not sure that I put the closing parentheses at their correct place)…
( http://stackoverflow.com/questions/25445439/what-does-syntaxerror-missing-parentheses-in-call-to-print-mean-in-python )