### PR TITLE
Enable symlinking to zotero launch script

### DIFF
--- a/linux/zotero
+++ b/linux/zotero
@@ -1,3 +1,3 @@
-#!/bin/bash
-CALLDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#!/bin/sh
+CALLDIR="$(dirname "$(readlink -f "$0")")"
 "$CALLDIR/zotero-bin" -app "$CALLDIR/application.ini" $*


### PR DESCRIPTION
As it stands now, if one places the Zotero application directory somewhere, then puts a symlink
to the `zotero` script in a directory in their path (such as `~/bin`), the `zotero` script will try
to launch Zotero from the directory holding the symlink, not the location of the actual script.

This approach fixes that AND removes a bashism, so this should be more "cross-platform".

NOTE: I have not tested the mac script, since I don't have access to a Mac to test on.