### PR TITLE
Support building for Windows on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,7 +194,6 @@ perl -pi -e "s/\{\{BUILDID}}/$BUILD_ID/" "$BUILD_DIR/application.ini"
 # Copy prefs.js and modify
 cp "$CALLDIR/assets/prefs.js" "$BUILD_DIR/zotero/defaults/preferences"
 perl -pi -e 's/pref\("app\.update\.channel", "[^"]*"\);/pref\("app\.update\.channel", "'"$UPDATE_CHANNEL"'");/' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
-perl -pi -e 's/%GECKO_VERSION%/'"$GECKO_VERSION"'/g' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
 
 # Add devtools manifest and pref
 if [ $DEVTOOLS -eq 1 ]; then
@@ -228,6 +227,7 @@ if [ $BUILD_MAC == 1 ]; then
 	
 	# Modify platform-specific prefs
 	perl -pi -e 's/pref\("browser\.preferences\.instantApply", false\);/pref\("browser\.preferences\.instantApply", true);/' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
+	perl -pi -e 's/%GECKO_VERSION%/'"$GECKO_VERSION_MAC"'/g' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
 	
 	# Merge relevant assets from Firefox
 	mkdir "$CONTENTSDIR/MacOS"
@@ -319,6 +319,9 @@ if [ $BUILD_WIN32 == 1 ]; then
 	APPDIR="$STAGE_DIR/Zotero_win32"
 	rm -rf "$APPDIR"
 	mkdir "$APPDIR"
+	
+	# Modify platform-specific prefs
+	perl -pi -e 's/%GECKO_VERSION%/'"$GECKO_VERSION_WIN"'/g' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
 	
 	# Copy relevant assets from Firefox
 	mkdir "$APPDIR/xulrunner"
@@ -470,6 +473,7 @@ if [ $BUILD_LINUX == 1 ]; then
 		
 		# Modify platform-specific prefs
 		perl -pi -e 's/pref\("browser\.preferences\.instantApply", false\);/pref\("browser\.preferences\.instantApply", true);/' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
+		perl -pi -e 's/%GECKO_VERSION%/'"$GECKO_VERSION_LINUX"'/g' "$BUILD_DIR/zotero/defaults/preferences/prefs.js"
 		
 		# Add Unix-specific Standalone assets
 		cd "$CALLDIR/assets/unix"

--- a/config.sh
+++ b/config.sh
@@ -3,13 +3,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Version of Gecko to build with
 #
 # xulrunner-stub.exe currently requires <=47, though it can probably be rebuilt against a later SDK
-if [ "`uname -o 2> /dev/null`" = 'Cygwin' ]; then
-	GECKO_VERSION="45.0.2esr"
-	GECKO_SHORT_VERSION="45.0"
-else
-	GECKO_VERSION="50.1.0"
-	GECKO_SHORT_VERSION="50.1"
-fi
+GECKO_VERSION_MAC="50.1.0"
+GECKO_VERSION_LINUX="50.1.0"
+GECKO_VERSION_WIN="45.0.2esr"
 
 # Paths to Gecko runtimes
 MAC_RUNTIME_PATH="$DIR/xulrunner/Firefox.app"

--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -21,7 +21,6 @@ set -euo pipefail
 
 CALLDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . "$CALLDIR/config.sh"
-DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/$GECKO_VERSION"
 
 function usage {
 	cat >&2 <<DONE
@@ -108,11 +107,12 @@ function extract_devtools {
 	set -e
 }
 
-rm -rf xulrunner
-mkdir xulrunner
+mkdir -p xulrunner
 cd xulrunner
 
 if [ $BUILD_MAC == 1 ]; then
+	GECKO_VERSION="$GECKO_VERSION_MAC"
+	DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/$GECKO_VERSION"
 	rm -rf Firefox.app
 	
 	curl -O "$DOWNLOAD_URL/mac/en-US/Firefox%20$GECKO_VERSION.dmg"
@@ -132,6 +132,9 @@ if [ $BUILD_MAC == 1 ]; then
 fi
 
 if [ $BUILD_WIN32 == 1 ]; then
+	GECKO_VERSION="$GECKO_VERSION_WIN"
+	DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/$GECKO_VERSION"
+	
 	XDIR=firefox-win32
 	rm -rf $XDIR
 	mkdir $XDIR
@@ -152,6 +155,8 @@ if [ $BUILD_WIN32 == 1 ]; then
 fi
 
 if [ $BUILD_LINUX == 1 ]; then
+	GECKO_VERSION="$GECKO_VERSION_LINUX"
+	DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/$GECKO_VERSION"
 	rm -rf firefox
 	
 	curl -O "$DOWNLOAD_URL/linux-i686/en-US/firefox-$GECKO_VERSION.tar.bz2"

--- a/scripts/dir_build
+++ b/scripts/dir_build
@@ -5,13 +5,37 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 . "$ROOT_DIR/config.sh"
 
+function usage {
+	cat >&2 <<DONE
+Usage: $0 -p platforms
+Options
+ -p PLATFORMS        Platforms to build (m=Mac, w=Windows, l=Linux)
+ -t                  add devtools
+DONE
+	exit 1
+}
+
 DEVTOOLS=0
-while getopts "t" opt; do
+PLATFORM=""
+while getopts "p:t" opt; do
 	case $opt in
 		t)
 			DEVTOOLS=1
 			;;
-		
+		p)
+			for i in `seq 0 1 $((${#OPTARG}-1))`
+			do
+				case ${OPTARG:i:1} in
+					m) PLATFORM="m";;
+					w) PLATFORM="w";;
+					l) PLATFORM="l";;
+					*)
+						echo "$0: Invalid platform option ${OPTARG:i:1}"
+						usage
+						;;
+				esac
+			done
+			;;		
 		\?)
 			echo "Invalid option: -$OPTARG" >&2
 			exit 1
@@ -19,12 +43,14 @@ while getopts "t" opt; do
 	esac
 done
 
-if [ "`uname`" = "Darwin" ]; then
-	PLATFORM="m"
-elif [ "`uname`" = "Linux" ]; then
-	PLATFORM="l"
-elif [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then
-	PLATFORM="w"
+if [[ -z $PLATFORM ]]; then
+	if [ "`uname`" = "Darwin" ]; then
+		PLATFORM="m"
+	elif [ "`uname`" = "Linux" ]; then
+		PLATFORM="l"
+	elif [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then
+		PLATFORM="w"
+	fi
 fi
 
 CHANNEL="source"


### PR DESCRIPTION
Building on a Windows VM is stupidly slow, but we use no
platform-specific tools to not support building non-native builds.
Signing, naturally, has not been tested, but a Windows build, built on
Linux, works on Windows as expected.

This naturally extends to support other cross-platform builds, with
MacOS being the prime contender for building for all platforms.