### PR TITLE
linux: exit shell when launching zotero-bin

### DIFF
--- a/linux/zotero
+++ b/linux/zotero
@@ -10,4 +10,4 @@
 ulimit -n 4096
 
 CALLDIR="$(dirname "$(readlink -f "$0")")"
-"$CALLDIR/zotero-bin" -app "$CALLDIR/application.ini" "$@"
+exec "$CALLDIR/zotero-bin" -app "$CALLDIR/application.ini" "$@"


### PR DESCRIPTION
Without "exec", the shell process that is executing the wrapper script will stay alive until zotero-bin exits. There's no need for this, so we use "exec" to let the zotero-bin process take over the shell process.