### PR TITLE
Add MIME type for linux .desktop

### DIFF
--- a/linux/zotero.desktop
+++ b/linux/zotero.desktop
@@ -5,4 +5,4 @@ Icon=zotero.ico
 Type=Application
 Terminal=false
 Categories=Office;
-MimeType=text/plain
+MimeType=text/plain;x-scheme-handler/zotero;application/x-endnote-refer;application/x-research-info-systems;text/ris;text/x-research-info-systems;application/x-inst-for-Scientific-info;application/mods+xml;application/rdf+xml;application/x-bibtex;text/x-bibtex;application/marc;application/vnd.citationstyles.style+xml


### PR DESCRIPTION
Add MIME type that must be registered to Zotero in `.desktop` file.
Based upon the mime types listed in [the code here](https://github.com/retorquere/zotero-deb/blob/52009246fc132112f012b85dac33e82667afa208/build.py#L161-L174)