### PR TITLE
Add "X-GNOME-SingleWindow=true" to the desktop file

### DIFF
--- a/linux/zotero.desktop
+++ b/linux/zotero.desktop
@@ -6,3 +6,4 @@ Type=Application
 Terminal=false
 Categories=Office;
 MimeType=text/plain;x-scheme-handler/zotero;application/x-research-info-systems;text/x-research-info-systems;text/ris;application/x-endnote-refer;application/x-inst-for-Scientific-info;application/mods+xml;application/rdf+xml;application/x-bibtex;text/x-bibtex;application/marc;application/vnd.citationstyles.style+xml
+X-GNOME-SingleWindow=true


### PR DESCRIPTION
Since this commit (https://github.com/KDE/plasma-workspace/commit/ebd2acd98ecdb9d115b01bd01f532390376152f7),
Plasma Desktop will check "X-GNOME-SingleWindow" property to determine
whether to show "Open New Window" action in the context menu of a task.

Zotero cannot launch a new instance or open a new window, so add the
property and set it to true to hide the action.