### PR TITLE
Change X-GNOME-SingleWindow key to SingleMainWindow

### DIFF
--- a/linux/zotero.desktop
+++ b/linux/zotero.desktop
@@ -6,4 +6,4 @@ Type=Application
 Terminal=false
 Categories=Office;
 MimeType=text/plain;x-scheme-handler/zotero;application/x-research-info-systems;text/x-research-info-systems;text/ris;application/x-endnote-refer;application/x-inst-for-Scientific-info;application/mods+xml;application/rdf+xml;application/x-bibtex;text/x-bibtex;application/marc;application/vnd.citationstyles.style+xml
-X-GNOME-SingleWindow=true
+SingleMainWindow=true


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name
"SingleMainWindow" in
https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53