### PR TITLE
Replace git:// URLs with HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "modules/zotero-word-for-mac-integration"]
 	path = modules/zotero-word-for-mac-integration
-	url = git://github.com/zotero/zotero-word-for-mac-integration.git
+	url = https://github.com/zotero/zotero-word-for-mac-integration.git
 [submodule "modules/zotero-word-for-windows-integration"]
 	path = modules/zotero-word-for-windows-integration
-	url = git://github.com/zotero/zotero-word-for-windows-integration.git
+	url = https://github.com/zotero/zotero-word-for-windows-integration.git
 [submodule "modules/zotero-libreoffice-integration"]
 	path = modules/zotero-libreoffice-integration
-	url = git://github.com/zotero/zotero-libreoffice-integration.git
+	url = https://github.com/zotero/zotero-libreoffice-integration.git


### PR DESCRIPTION
Cloning repo recursively currently fails because GitHub dropped support for the unencrypted Git protocol:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Same change as [zotero@6240e08ca0d6d1d2c1fefe3e9543c4aa470cef57](https://github.com/zotero/zotero/commit/6240e08ca0d6d1d2c1fefe3e9543c4aa470cef57)