### PR TITLE
Revert to X-GNOME-SingleWindow

### DIFF
--- a/linux/zotero.desktop
+++ b/linux/zotero.desktop
@@ -6,4 +6,4 @@ Type=Application
 Terminal=false
 Categories=Office;
 MimeType=text/plain;x-scheme-handler/zotero;application/x-research-info-systems;text/x-research-info-systems;text/ris;application/x-endnote-refer;application/x-inst-for-Scientific-info;application/mods+xml;application/rdf+xml;application/x-bibtex;text/x-bibtex;application/marc;application/vnd.citationstyles.style+xml
-SingleMainWindow=true
+X-GNOME-SingleWindow=true


### PR DESCRIPTION
The SingleMainWindow key might be upstream, but it is still not used in most systems.

Another solution is to add the Version=1.5 as the first entry of the Desktop Entry, since that is the version in which the key was enabled.
Without the version set the flatpak will not build.

It is worth noting that for backwards compatibility (e.g. with current versions of ubuntu) the flag should be reverted to X-GNOME-SingleWindow.