### PR TITLE
Download AArch64 version of xulrunner

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -13,6 +13,7 @@ MAC_RUNTIME_PATH="$DIR/xulrunner/Firefox.app"
 WIN32_RUNTIME_PATH="$DIR/xulrunner/firefox-win32"
 LINUX_i686_RUNTIME_PATH="$DIR/xulrunner/firefox-i686"
 LINUX_x86_64_RUNTIME_PATH="$DIR/xulrunner/firefox-x86_64"
+LINUX_aarch64_RUNTIME_PATH="$DIR/xulrunner/firefox-aarch64"
 
 PDF_TOOLS_VERSION="0.0.5"
 PDF_TOOLS_URL="https://zotero-download.s3.amazonaws.com/pdftools/pdftools-$PDF_TOOLS_VERSION.tar.gz"

--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -254,6 +254,25 @@ if [ $BUILD_LINUX == 1 ]; then
 	cd ..
 	
 	rm "firefox-$GECKO_VERSION.tar.bz2"
+
+	curl -OL "https://answers.launchpad.net/~mozillateam/+archive/ubuntu/ppa/+build/17514808/+files/firefox-esr_60.9.0esr+build1-0ubuntu0.14.04.1_arm64.deb"
+	rm -rf firefox-aarch64{,-tmp}
+	mkdir firefox-aarch64-tmp
+	cd firefox-aarch64-tmp
+	ar x ../firefox-esr_60.9.0esr+build1-0ubuntu0.14.04.1_arm64.deb
+	tar xvf data.tar.*
+	mv usr/lib/firefox-esr ../firefox-aarch64
+
+	cd ../firefox-aarch64
+	mv firefox-esr firefox
+	rm firefox.sh
+	rm -rf distribution
+	modify_omni linux64
+	extract_devtools
+	cd ..
+
+	rm firefox-esr_60.9.0esr+build1-0ubuntu0.14.04.1_arm64.deb
+	rm -rf firefox-aarch64-tmp
 fi
 
 echo Done


### PR DESCRIPTION
AFAICT mozilla still don't provide aarch64 binary on linux and this is the first/only place I found that provide the firefox binary for the same version used on other platforms. Feel free to suggest other download sources...

This is the main change I needed to produce a working package for aarch64. Once https://github.com/zotero/cross-xpdf/pull/1 or equivalent of it is merged and deployed, the rest of the changes should be really simple (if we accept leaving the updater broken for aarch64).
