### PR TITLE
add missing string conversion

### DIFF
--- a/scripts/optimizejars.py
+++ b/scripts/optimizejars.py
@@ -356,7 +356,7 @@ def deoptimize(JAR_LOG_DIR, IN_JAR_DIR, OUT_JAR_DIR):
         injarfile = os.path.join(IN_JAR_DIR, jarfile)
         outjarfile = os.path.join(OUT_JAR_DIR, jarfile) 
         logfile = os.path.join(JAR_LOG_DIR, jarfile + ".log")
-        log = optimizejar(injarfile, outjarfile, None)
+        log = str(optimizejar(injarfile, outjarfile, None))
         open(logfile, "wb").write("\n".join(log).encode('utf-8'))
 
 def main():        


### PR DESCRIPTION
without this the build fails like so:
```
Deoptimized 183/1273 in ./omni.ja
Traceback (most recent call last):
  File "/var/tmp/pamac-build-seirra/zotero-git/src/zotero-standalone-build/scripts/optimizejars.py", line 376, in <module>
    main()
  File "/var/tmp/pamac-build-seirra/zotero-git/src/zotero-standalone-build/scripts/optimizejars.py", line 370, in main
    deoptimize(JAR_LOG_DIR, IN_JAR_DIR, OUT_JAR_DIR)
  File "/var/tmp/pamac-build-seirra/zotero-git/src/zotero-standalone-build/scripts/optimizejars.py", line 360, in deoptimize
    open(logfile, "wb").write("\n".join(log).encode('utf-8'))
TypeError: sequence item 0: expected str instance, bytes found
==> ERROR: A failure occurred in build().
```
the python version used was 3.10.4