### PR TITLE
Support adding multiple files in add_omni script

### DIFF
--- a/scripts/add_omni_file
+++ b/scripts/add_omni_file
@@ -22,12 +22,15 @@ DONE
 if [ -z "${1:-}" ]; then
 	usage
 fi
-file="$1"
 
-if [ ! -f "$file" ]; then
-	echo "Error: $file not found!"
-	exit 1
-fi
+files="$@"
+
+for file in $files; do
+	if [ ! -f "$file" ]; then
+		echo "Error: $file not found!"
+		exit 1
+	fi
+done
 
 mac_path="$STAGE_DIR/Zotero.app/Contents/Resources"
 win_path="$STAGE_DIR/Zotero_win32"
@@ -36,8 +39,9 @@ linux_path="$STAGE_DIR/Zotero_win32"
 added=0
 for path in "$mac_path" "$win_path" "$linux_path"; do
 	if [ -d "$path" ]; then
+		echo "$path/app/omni.ja"
 		echo "Updating $(basename $(dirname $(dirname $path)))"
-		zip "$path/app/omni.ja" "$file"
+		zip "$path/app/omni.ja" $files
 		added=1
 	fi
 done


### PR DESCRIPTION
A single change in a source file in [zotero/zotero](github.com/zotero/zotero) may result in multiple files produced, e.g. `scss` files will produce three `css` file variants for different platforms. It's much faster (and more elegant) to have zip updated once, instead of running `add_omni_file` multiple times sequentially, hence this PR.