### PR TITLE
fx-compat: Fix first dialog resizing after display, use native checkbox

### DIFF
--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -145,6 +145,9 @@ function modify_omni {
 	#  echo '.detail-view-container #warning-container { display: none; }' >> chrome/toolkit/content/mozapps/extensions/extensions.css
 	#  # Hide legacy label
 	#  echo '.legacy-warning { display: none; }' >> chrome/toolkit/content/mozapps/extensions/extensions.css
+
+	perl -pi -e 's/window.sizeToContent\(\);/if (ui.infoIcon.complete) window.sizeToContent();/' chrome/toolkit/content/global/commonDialog.js
+	perl -pi -e 's/ui.infoIcon.addEventListener/if (!ui.infoIcon.complete) ui.infoIcon.addEventListener/' chrome/toolkit/content/global/commonDialog.js
 	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..

--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -148,11 +148,11 @@ function modify_omni {
 	
 	# The first displayed Services.prompt dialog's size jumps around because sizeToContent() is called twice
 	# Fix by preventing the first sizeToContent() call if the icon hasn't been loaded yet
-	perl -pi -e 's/window.sizeToContent\(\);/if (ui.infoIcon.complete) window.sizeToContent();/' chrome/toolkit/content/global/commonDialog.js
-	perl -pi -e 's/ui.infoIcon.addEventListener/if (!ui.infoIcon.complete) ui.infoIcon.addEventListener/' chrome/toolkit/content/global/commonDialog.js
+	replace_line 'window.sizeToContent\(\);' 'if (ui.infoIcon.complete) window.sizeToContent();' chrome/toolkit/content/global/commonDialog.js
+	replace_line 'ui.infoIcon.addEventListener' 'if (!ui.infoIcon.complete) ui.infoIcon.addEventListener' chrome/toolkit/content/global/commonDialog.js
 	
-	# Use native checkbox instead of Firefox-themed version
-	perl -pi -e 's/<xul:checkbox/<xul:checkbox native=\"true\"/' chrome/toolkit/content/global/commonDialog.xhtml
+	# Use native checkbox instead of Firefox-themed version in prompt dialogs
+	replace_line '<xul:checkbox' '<xul:checkbox native=\"true\"' chrome/toolkit/content/global/commonDialog.xhtml
 	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..

--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -145,7 +145,9 @@ function modify_omni {
 	#  echo '.detail-view-container #warning-container { display: none; }' >> chrome/toolkit/content/mozapps/extensions/extensions.css
 	#  # Hide legacy label
 	#  echo '.legacy-warning { display: none; }' >> chrome/toolkit/content/mozapps/extensions/extensions.css
-
+	
+	# The first displayed Services.prompt dialog's size jumps around because sizeToContent() is called twice
+	# Fix by preventing the first sizeToContent() call if the icon hasn't been loaded yet
 	perl -pi -e 's/window.sizeToContent\(\);/if (ui.infoIcon.complete) window.sizeToContent();/' chrome/toolkit/content/global/commonDialog.js
 	perl -pi -e 's/ui.infoIcon.addEventListener/if (!ui.infoIcon.complete) ui.infoIcon.addEventListener/' chrome/toolkit/content/global/commonDialog.js
 	

--- a/fetch_xulrunner.sh
+++ b/fetch_xulrunner.sh
@@ -151,6 +151,9 @@ function modify_omni {
 	perl -pi -e 's/window.sizeToContent\(\);/if (ui.infoIcon.complete) window.sizeToContent();/' chrome/toolkit/content/global/commonDialog.js
 	perl -pi -e 's/ui.infoIcon.addEventListener/if (!ui.infoIcon.complete) ui.infoIcon.addEventListener/' chrome/toolkit/content/global/commonDialog.js
 	
+	# Use native checkbox instead of Firefox-themed version
+	perl -pi -e 's/<xul:checkbox/<xul:checkbox native=\"true\"/' chrome/toolkit/content/global/commonDialog.xhtml
+	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..
 	cd ..


### PR DESCRIPTION
Running sizeToContent() only once (immediately if the image is already loaded, later if it isn't) seems to do the trick - the dialog has the correct size and doesn't jump around after showing.

Fixes zotero/zotero#2703.