### PR TITLE
Win64 installer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -581,7 +581,11 @@ if [ $BUILD_WIN == 1 ]; then
 		
 		# Build uninstaller
 		perl -pi -e "s/\{\{VERSION}}/$VERSION/" "$BUILD_DIR/win_installer/defines.nsi"
-		"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+		if [ $arch = "win32" ]; then
+			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+		elif [ $arch = "win64" ]; then
+			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+		
 		mkdir "$COMMON_APPDIR/uninstall"
 		mv "$BUILD_DIR/win_installer/helper.exe" "$COMMON_APPDIR/uninstall"
 		
@@ -727,7 +731,11 @@ if [ $BUILD_WIN == 1 ]; then
 				cp -r "$APPDIR" "$INSTALLER_STAGE_DIR/core"
 				
 				# Build and sign setup.exe
-				"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
+				if [ $arch = "win32" ]; then
+					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
+				elif [ $arch = "win64" ]; then
+					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
+				fi
 				mv "$BUILD_DIR/win_installer/setup.exe" "$INSTALLER_STAGE_DIR"
 				if [ $SIGN == 1 ]; then
 					"`cygpath -u \"$SIGNTOOL\"`" \

--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ else
 fi
 
 # Bundle devtools with dev builds
-if [ $UPDATE_CHANNEL == "beta" ] || [ $UPDATE_CHANNEL == "dev" ] || [ $UPDATE_CHANNEL == "test" ]; then
+if [ "$UPDATE_CHANNEL" == "beta" ] || [ "$UPDATE_CHANNEL" == "dev" ] || [ "$UPDATE_CHANNEL" == "test" ]; then
 	DEVTOOLS=1
 fi
 if [ -z "$UPDATE_CHANNEL" ]; then UPDATE_CHANNEL="default"; fi
@@ -581,10 +581,11 @@ if [ $BUILD_WIN == 1 ]; then
 		
 		# Build uninstaller
 		perl -pi -e "s/\{\{VERSION}}/$VERSION/" "$BUILD_DIR/win_installer/defines.nsi"
-		if [ $arch = "win32" ]; then
+		if [ "$arch" = "win32" ]; then
 			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
-		elif [ $arch = "win64" ]; then
+		elif [ "$arch" = "win64" ]; then
 			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+		fi			
 		
 		mkdir "$COMMON_APPDIR/uninstall"
 		mv "$BUILD_DIR/win_installer/helper.exe" "$COMMON_APPDIR/uninstall"
@@ -705,9 +706,9 @@ if [ $BUILD_WIN == 1 ]; then
 			if [ $WIN_NATIVE -eq 1 ]; then
 				echo "Creating Windows installer"
 				
-				if [ $arch = "win32" ]; then
+				if [ "$arch" = "win32" ]; then
 					INSTALLER_PATH="$DIST_DIR/Zotero-${VERSION}_win32_setup.exe"
-				elif [ $arch = "win64" ]; then
+				elif [ "$arch" = "win64" ]; then
 					INSTALLER_PATH="$DIST_DIR/Zotero-${VERSION}_setup.exe"
 				fi
 				
@@ -731,9 +732,9 @@ if [ $BUILD_WIN == 1 ]; then
 				cp -r "$APPDIR" "$INSTALLER_STAGE_DIR/core"
 				
 				# Build and sign setup.exe
-				if [ $arch = "win32" ]; then
+				if [ "$arch" = "win32" ]; then
 					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
-				elif [ $arch = "win64" ]; then
+				elif [ "$arch" = "win64" ]; then
 					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
 				fi
 				mv "$BUILD_DIR/win_installer/setup.exe" "$INSTALLER_STAGE_DIR"

--- a/build.sh
+++ b/build.sh
@@ -578,23 +578,15 @@ if [ $BUILD_WIN == 1 ]; then
 	if [ $PACKAGE -eq 1 ]; then
 		# Copy installer files
 		cp -r "$CALLDIR/win/installer" "$BUILD_DIR/win_installer"
-		
-		# Build uninstaller
+
 		perl -pi -e "s/\{\{VERSION}}/$VERSION/" "$BUILD_DIR/win_installer/defines.nsi"
-		if [ "$arch" = "win32" ]; then
-			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
-		elif [ "$arch" = "win64" ]; then
-			"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
-		fi			
-		
 		mkdir "$COMMON_APPDIR/uninstall"
-		mv "$BUILD_DIR/win_installer/helper.exe" "$COMMON_APPDIR/uninstall"
 		
 		# Use our own updater, because Mozilla's requires updates signed by Mozilla
 		cp "$CALLDIR/win/updater.exe" "$COMMON_APPDIR"
 		cat "$CALLDIR/win/installer/updater_append.ini" >> "$COMMON_APPDIR/updater.ini"
 		
-		# Sign PDF tools, uninstaller, and updater
+		# Sign PDF tools and updater
 		if [ $SIGN -eq 1 ]; then
 			"`cygpath -u \"$SIGNTOOL\"`" \
 				sign /n "$SIGNTOOL_CERT_SUBJECT" \
@@ -611,14 +603,6 @@ if [ $BUILD_WIN == 1 ]; then
 				/tr "$SIGNTOOL_TIMESTAMP_SERVER" \
 				/td SHA256 \
 				"`cygpath -w \"$COMMON_APPDIR/pdfinfo.exe\"`"
-			sleep $SIGNTOOL_DELAY
-			"`cygpath -u \"$SIGNTOOL\"`" \
-				sign /n "$SIGNTOOL_CERT_SUBJECT" \
-				/d "$SIGNATURE_DESC Uninstaller" \
-				/fd SHA256 \
-				/tr "$SIGNTOOL_TIMESTAMP_SERVER" \
-				/td SHA256 \
-				"`cygpath -w \"$COMMON_APPDIR/uninstall/helper.exe\"`"
 			sleep $SIGNTOOL_DELAY
 			"`cygpath -u \"$SIGNTOOL\"`" \
 				sign /n "$SIGNTOOL_CERT_SUBJECT" \
@@ -705,6 +689,26 @@ if [ $BUILD_WIN == 1 ]; then
 		if [ $PACKAGE -eq 1 ]; then
 			if [ $WIN_NATIVE -eq 1 ]; then
 				echo "Creating Windows installer"
+				# Build uninstaller
+				if [ "$arch" = "win32" ]; then
+					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+				elif [ "$arch" = "win64" ]; then
+					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/uninstaller.nsi\"`"
+				fi
+
+				mv "$BUILD_DIR/win_installer/helper.exe" "$APPDIR/uninstall"
+
+				if [ $SIGN -eq 1 ]; then
+					"`cygpath -u \"$SIGNTOOL\"`" \
+						sign /n "$SIGNTOOL_CERT_SUBJECT" \
+						/d "$SIGNATURE_DESC Uninstaller" \
+						/fd SHA256 \
+						/tr "$SIGNTOOL_TIMESTAMP_SERVER" \
+						/td SHA256 \
+						"`cygpath -w \"$APPDIR/uninstall/helper.exe\"`"
+					sleep $SIGNTOOL_DELAY
+				fi
+				
 				
 				if [ "$arch" = "win32" ]; then
 					INSTALLER_PATH="$DIST_DIR/Zotero-${VERSION}_win32_setup.exe"
@@ -732,12 +736,14 @@ if [ $BUILD_WIN == 1 ]; then
 				cp -r "$APPDIR" "$INSTALLER_STAGE_DIR/core"
 				
 				# Build and sign setup.exe
-				if [ "$arch" = "win32" ]; then
+				if [ "$arch" = "win32" ]; then	
 					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
 				elif [ "$arch" = "win64" ]; then
 					"`cygpath -u \"${NSIS_DIR}makensis.exe\"`" /DHAVE_64BIT_OS /V1 "`cygpath -w \"$BUILD_DIR/win_installer/installer.nsi\"`"
 				fi
+
 				mv "$BUILD_DIR/win_installer/setup.exe" "$INSTALLER_STAGE_DIR"
+
 				if [ $SIGN == 1 ]; then
 					"`cygpath -u \"$SIGNTOOL\"`" \
 						sign /n "$SIGNTOOL_CERT_SUBJECT" \

--- a/win/installer/common.nsh
+++ b/win/installer/common.nsh
@@ -4152,7 +4152,7 @@ FunctionEnd
 
       !ifdef HAVE_64BIT_OS
         ${Unless} ${RunningX64}
-        ${OrUnless} ${AtLeastWinVista}
+        ${OrUnless} ${AtLeastWin7}
           MessageBox MB_OK|MB_ICONSTOP "$R9" IDOK
           ; Nothing initialized so no need to call OnEndCommon
           Quit
@@ -4160,35 +4160,10 @@ FunctionEnd
 
         SetRegView 64
       !else
-        StrCpy $R8 "0"
-        ${If} ${AtMostWin2000}
-          StrCpy $R8 "1"
-        ${EndIf}
-
-        ${If} ${IsWinXP}
-        ${AndIf} ${AtMostServicePack} 1
-          StrCpy $R8 "1"
-        ${EndIf}
-
-        ${If} $R8 == "1"
-          ; XXX-rstrong - some systems failed the AtLeastWin2000 test that we
-          ; used to use for an unknown reason and likely fail the AtMostWin2000
-          ; and possibly the IsWinXP test as well. To work around this also
-          ; check if the Windows NT registry Key exists and if it does if the
-          ; first char in CurrentVersion is equal to 3 (Windows NT 3.5 and
-          ; 3.5.1), to 4 (Windows NT 4) or 5 (Windows 2000 and Windows XP).
-          StrCpy $R8 ""
-          ClearErrors
-          ReadRegStr $R8 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" "CurrentVersion"
-          StrCpy $R8 "$R8" 1
-          ${If} ${Errors}
-          ${OrIf} "$R8" == "3"
-          ${OrIf} "$R8" == "4"
-          ${OrIf} "$R8" == "5"
-            MessageBox MB_OK|MB_ICONSTOP "$R9" IDOK
-            ; Nothing initialized so no need to call OnEndCommon
-            Quit
-          ${EndIf}
+        ${Unless} ${AtLeastWin7}
+          MessageBox MB_OK|MB_ICONSTOP "$R9" IDOK
+          ; Nothing initialized so no need to call OnEndCommon
+          Quit
         ${EndUnless}
       !endif
 

--- a/win/installer/defines.nsi
+++ b/win/installer/defines.nsi
@@ -42,8 +42,13 @@
 
 # ARCH is used when it is necessary to differentiate the x64 registry keys from
 # the x86 registry keys (e.g. the uninstall registry key).
-!define ARCH "x86"
-!define MinSupportedVer "Microsoft Windows XP SP2"
+!ifdef HAVE_64BIT_OS
+    !define ARCH "x86"
+    !define MinSupportedVer "64-bit Microsoft Windows 7"
+!else
+    !define ARCH "x64"
+    !define MinSupportedVer "Microsoft Windows 7"
+!endif
 
 # File details shared by both the installer and uninstaller
 VIProductVersion "1.0.0.0"

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -167,6 +167,71 @@ Page custom preSummary
 ; Use the default dialog for IDD_VERIFY for a simple Banner
 ChangeUI IDD_VERIFY "${NSISDIR}\Contrib\UIs\default.exe"
 
+; If a version beginning with $R1 is installed, uninstall that.
+; This is used to uninstall the old Zotero Standalone installer and a 32-bit version on 64-bit Windows
+Function UninstallOld
+  Push $R1
+  Push $R2
+  StrCpy $0 0
+  
+  enum_uninst_keys:
+    EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall" $0
+    StrCmp $1 "" continue_installation
+    ; $R1 migth be "Zotero Standalone" or "Zotero", registry key name contains version and locale e.g. "Zotero 6.0.0 (x86 en-US)" so:
+    StrLen $3 $R1 ; $3 = length of $R1, e.g. 17 for "Zotero Standalone"
+    StrCpy $2 $1 $3 ; $2 = first $3 characters of $1, i.e. name without version and locale, e.g. "Zotero Standalone"
+    StrCmp $2 $R1 get_uninst_exe ; if the key we found is the one we're looking for (e.g. "Zotero Standalone"), go to get_uninst_exe
+    IntOp $0 $0 + 1 
+    Goto enum_uninst_keys ; loop through all keys
+  
+  get_uninst_exe:
+    ReadRegStr $2 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "UninstallString"
+    ReadRegStr $3 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "InstallLocation"
+  
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+    $R2 \
+    /SD IDOK IDOK uninst
+  Abort
+  
+  uninst:
+    ; This doesn't actually wait, since the uninstaller copies itself to a temp folder, runs that,
+    ; and exits, so give it a few seconds to finish
+    ExecWait '"$2" /S'
+    Sleep 3000
+    
+    ; Files that were added by an in-app update won't be automatically deleted by the 4.0 uninstaller,
+    ; so manually delete everything we know about as long as the directory name begins with "Zotero".
+    ; We don't just delete the directory because we don't know for sure that the user didn't do
+    ; something crazy like put their data directory in it.
+    ${GetFileName} $3 $4
+    StrCpy $5 $4 6
+    StrCmp $5 "Zotero" +1 continue_installation
+    RMDir /r /REBOOTOK "$3\chrome"
+    RMDir /r /REBOOTOK "$3\components"
+    RMDir /r /REBOOTOK "$3\defaults"
+    RMDir /r /REBOOTOK "$3\dictionaries"
+    RMDir /r /REBOOTOK "$3\extensions"
+    RMDir /r /REBOOTOK "$3\fonts"
+    RMDir /r /REBOOTOK "$3\gmp-clearkey"
+    RMDir /r /REBOOTOK "$3\uninstall"
+    RMDir /r /REBOOTOK "$3\xulrunner"
+    Delete /REBOOTOK "$3\*.chk"
+    Delete /REBOOTOK "$3\*.dll"
+    Delete /REBOOTOK "$3\*.exe"
+    Delete /REBOOTOK "$3\Accessible.tlb"
+    Delete /REBOOTOK "$3\dependentlibs.list"
+    Delete /REBOOTOK "$3\firefox.VisualElementsManifest.xml"
+    Delete /REBOOTOK "$3\omni.ja"
+    Delete /REBOOTOK "$3\platform.ini"
+    Delete /REBOOTOK "$3\precomplete"
+    Delete /REBOOTOK "$3\voucher.bin"
+    RMDir /REBOOTOK $3
+  continue_installation:
+    ; End uninstallation
+    Pop $R2
+    Pop $R1
+FunctionEnd
+
 ################################################################################
 # Install Sections
 
@@ -859,64 +924,17 @@ Function .onInit
 
   ${InstallOnInitCommon} "$(WARN_MIN_SUPPORTED_OS_MSG)"
 
-  ; If a version beginning with "Zotero Standalone" is installed, uninstall that first, since we're now
-  ; just "Zotero"
-  StrCpy $0 0
-  enum_uninst_keys:
-    EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall" $0
-    StrCmp $1 "" continue_installation
-    ; "Zotero Standalone" included a version suffix, so check the beginning
-    StrCpy $2 $1 17
-    StrCmp $2 "Zotero Standalone" get_uninst_exe
-    IntOp $0 $0 + 1
-    Goto enum_uninst_keys
-  
-  get_uninst_exe:
-    ReadRegStr $2 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "UninstallString"
-    ReadRegStr $3 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "InstallLocation"
-  
-  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-    "An older version of Zotero is installed. $\n$\nIf you continue, the existing version \
-    will be removed. Your Zotero data will not be affected." \
-    /SD IDOK IDOK uninst
-  Abort
-  
-  uninst:
-    ; This doesn't actually wait, since the uninstaller copies itself to a temp folder, runs that,
-    ; and exits, so give it a few seconds to finish
-    ExecWait '"$2" /S'
-    Sleep 3000
-    
-    ; Files that were added by an in-app update won't be automatically deleted by the 4.0 uninstaller,
-    ; so manually delete everything we know about as long as the directory name begins with "Zotero".
-    ; We don't just delete the directory because we don't know for sure that the user didn't do
-    ; something crazy like put their data directory in it.
-    ${GetFileName} $3 $4
-    StrCpy $5 $4 6
-    StrCmp $5 "Zotero" +1 continue_installation
-    RMDir /r /REBOOTOK "$3\chrome"
-    RMDir /r /REBOOTOK "$3\components"
-    RMDir /r /REBOOTOK "$3\defaults"
-    RMDir /r /REBOOTOK "$3\dictionaries"
-    RMDir /r /REBOOTOK "$3\extensions"
-    RMDir /r /REBOOTOK "$3\fonts"
-    RMDir /r /REBOOTOK "$3\gmp-clearkey"
-    RMDir /r /REBOOTOK "$3\uninstall"
-    RMDir /r /REBOOTOK "$3\xulrunner"
-    Delete /REBOOTOK "$3\*.chk"
-    Delete /REBOOTOK "$3\*.dll"
-    Delete /REBOOTOK "$3\*.exe"
-    Delete /REBOOTOK "$3\Accessible.tlb"
-    Delete /REBOOTOK "$3\dependentlibs.list"
-    Delete /REBOOTOK "$3\firefox.VisualElementsManifest.xml"
-    Delete /REBOOTOK "$3\omni.ja"
-    Delete /REBOOTOK "$3\platform.ini"
-    Delete /REBOOTOK "$3\precomplete"
-    Delete /REBOOTOK "$3\voucher.bin"
-    RMDir /REBOOTOK $3
-  continue_installation:
-  ; End uninstallation
+  StrCpy $R1 "Zotero Standalone"
+  StrCpy $R2 "An older version of Zotero is installed. $\n$\nIf you continue, the existing version will be removed. Your Zotero data will not be affected."
+  Call UninstallOld
 
+  !ifdef HAVE_64BIT_OS
+    SetRegView 32
+      StrCpy $R1 "Zotero"
+      StrCpy $R2 "A 32-bit version of Zotero is installed. $\n$\nThis installer installs 64-bit version, which offers better performance. If you continue, the existing version will be removed. Your Zotero data will not be affected."
+      Call UninstallOld
+    SetRegView 64
+  !endif
 
   !insertmacro InitInstallOptionsFile "options.ini"
   !insertmacro InitInstallOptionsFile "shortcuts.ini"

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -935,6 +935,17 @@ Function .onInit
       Call UninstallOld
     SetRegView 64
   !endif
+  
+  !ifndef HAVE_64BIT_OS
+    ${If} ${RunningX64}
+      MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+        "This installer is for a 32-bit version of Zotero but it appears you are running a 64-bit system. It is recommended that you install a 64-bit version which offers better performance. If you continue, a 32-bit version will be installed." \
+        /SD IDOK IDOK continue_architecture IDCANCEL cancel_architecture
+        cancel_architecture:
+          Abort
+        continue_architecture:
+    ${EndIf}
+  !endif
 
   !insertmacro InitInstallOptionsFile "options.ini"
   !insertmacro InitInstallOptionsFile "shortcuts.ini"

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -173,7 +173,7 @@ Function UninstallOld
   Push $R1
   Push $R2
   StrCpy $0 0
-  
+
   enum_uninst_keys:
     EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall" $0
     StrCmp $1 "" continue_installation
@@ -183,22 +183,22 @@ Function UninstallOld
     StrCmp $2 $R1 get_uninst_exe ; if the key we found is the one we're looking for (e.g. "Zotero Standalone"), go to get_uninst_exe
     IntOp $0 $0 + 1 
     Goto enum_uninst_keys ; loop through all keys
-  
+
   get_uninst_exe:
     ReadRegStr $2 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "UninstallString"
     ReadRegStr $3 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$1" "InstallLocation"
-  
+
   MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
     $R2 \
     /SD IDOK IDOK uninst
   Abort
-  
+
   uninst:
     ; This doesn't actually wait, since the uninstaller copies itself to a temp folder, runs that,
     ; and exits, so give it a few seconds to finish
     ExecWait '"$2" /S'
     Sleep 3000
-    
+
     ; Files that were added by an in-app update won't be automatically deleted by the 4.0 uninstaller,
     ; so manually delete everything we know about as long as the directory name begins with "Zotero".
     ; We don't just delete the directory because we don't know for sure that the user didn't do


### PR DESCRIPTION
This PR tweaks the build so that installer is aware of whether it contains a 32-bit or 64-bit version of Zotero and installs files into correct path and makes entries in correct tree in Windows registry [[1]](#1). It also adds logic so that uninstallers are built for both architectures.

I've added some new messages to cover all scenarios:

* Updating to 64-bit from 32-bit version on 64-bit system:
Shows OK/CANCEL warning, OK uninstalls 32-bit, continues; CANCEL exits
* Installing 32-bit on 64-bit system:
OK/CANCEL warning, OK installs anyways; CANCEL exits
* Installing 64-bit on 32-bit system:
ERROR (same as when installing on too old Windows, says it needs 64-bit Windows 7)

I've also tweaked the OS-detection logic so that it requires at least Windows 7.

Not sure if this behavior is ideal, suggestions welcome!

<sup id="1">1</sup> 32-bit app on 64-bit Windows goes into `Program Files (x86)` and has a special subnode in registry called `WOW6432Node`, this is where Zotero currently installs on 64-bit systems. After this change, 32-bit version on a 64-bit systems will still install there, but 64-bit version correctly installs to `Program Files` and "normal" registry node (same as 32-bit Zotero on a 32-bit system). Some of this code was already there, inherited from FF.

